### PR TITLE
Improve ability to paginate results

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ result.posts # will include all returned posts
 
 The `twinlgy-analytics` gem talks to a commercial blog search API and requires an API key. Best practice is to set the `TWINGLY_ANALYTICS_KEY` environment variable to the obtained key. `Twingly::Analytics::Client` can be passed a key at initialization if your setup does not allow environment variables.
 
+Example code can be found in [examples/](examples/).
+
 Too learn more about the capabilities of this API you should read the [Twingly Analytics API documentation](https://developer.twingly.com/resources/analytics/).
 
 ## Requirements

--- a/examples/hello_world.rb
+++ b/examples/hello_world.rb
@@ -4,7 +4,7 @@ Bundler.require
 client = Twingly::Analytics::Client.new
 query = client.query
 query.pattern = '"hello world"'
-query.start_time = Time.now - 86400
+query.start_time = Time.now - (24 * 3600) # search last day
 result = query.execute
 result.posts.each do |post|
   puts post.url

--- a/examples/hello_world.rb
+++ b/examples/hello_world.rb
@@ -1,0 +1,11 @@
+Bundler.require
+
+# Set environment variable TWINGLY_ANALYTICS_KEY
+client = Twingly::Analytics::Client.new
+query = client.query
+query.pattern = '"hello world"'
+query.start_time = Time.now - 86400
+result = query.execute
+result.posts.each do |post|
+  puts post.url
+end

--- a/lib/twingly-analytics/query.rb
+++ b/lib/twingly-analytics/query.rb
@@ -53,7 +53,7 @@ module Twingly
           faraday.request :url_encoded
           faraday.adapter Faraday.default_adapter
         end
-        connection.headers[:user_agent] = 'Ruby'
+        connection.headers[:user_agent] = "Twingly Analytics Ruby Client/#{VERSION}"
         connection.get(ANALYTICS_PATH, request_parameters)
       end
     end

--- a/lib/twingly-analytics/query.rb
+++ b/lib/twingly-analytics/query.rb
@@ -3,8 +3,7 @@ require 'faraday'
 module Twingly
   module Analytics
     class Query
-      attr_accessor :pattern, :language, :client
-      attr_reader :start_time, :end_time
+      attr_accessor :pattern, :language, :client, :start_time, :end_time
 
       BASE_URL = 'https://api.twingly.com'
       ANALYTICS_PATH = '/analytics/Analytics.ashx'
@@ -21,14 +20,6 @@ module Twingly
         Parser.new.parse(get_response.body)
       end
 
-      def start_time=(time)
-        @start_time = time.strftime("%F %T")
-      end
-
-      def end_time=(time)
-        @end_time = time.strftime("%F %T")
-      end
-
       def url_parameters
         Faraday::Utils.build_query(request_parameters)
       end
@@ -40,13 +31,21 @@ module Twingly
           :key => client.api_key,
           :searchpattern => pattern,
           :documentlang => language,
-          :ts => start_time,
-          :tsTo => end_time,
+          :ts => ts,
+          :tsTo => ts_to,
           :xmloutputversion => 2
         }
       end
 
     private
+
+      def ts
+        start_time.to_time.strftime("%F %T") if start_time
+      end
+
+      def ts_to
+        end_time.to_time.strftime("%F %T") if end_time
+      end
 
       def get_response
         connection = Faraday.new(:url => BASE_URL) do |faraday|

--- a/lib/twingly-analytics/result.rb
+++ b/lib/twingly-analytics/result.rb
@@ -8,6 +8,10 @@ module Twingly
         @posts ||= []
       end
 
+      def all_results_returned?
+        number_of_matches_returned.to_i == number_of_matches_total.to_i
+      end
+
       def inspect
         matches = "@posts, "
         matches << "@number_of_matches_returned=#{self.number_of_matches_returned}, "

--- a/spec/result_spec.rb
+++ b/spec/result_spec.rb
@@ -9,6 +9,7 @@ describe Result do
   it { should respond_to :number_of_matches_returned }
   it { should respond_to :number_of_matches_total }
   it { should respond_to :seconds_elapsed }
+  it { should respond_to :all_results_returned? }
 
   context "before query has populated responses" do
     its(:posts) { should be_empty }


### PR DESCRIPTION
* `Result#all_results_returned?` can tell you if you got all results or need to “paginate”
* Stop mutating the `start_time` and `end_time` objects
* Improved examples

If merged this will require a version bump before release. Probably a major since `start_time` and `end_time` response has been altered.